### PR TITLE
feat: remove ANSI escape sequences from output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/jstemmer/go-junit-report/v2
 
 go 1.13
 
-require github.com/google/go-cmp v0.5.8
+require (
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
+	github.com/google/go-cmp v0.5.8
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/junit/junit.go
+++ b/junit/junit.go
@@ -6,9 +6,10 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
 	"time"
+
+	"github.com/acarl005/stripansi"
 
 	"github.com/jstemmer/go-junit-report/v2/gtr"
 )
@@ -252,25 +253,17 @@ func formatDuration(d time.Duration) string {
 
 // formatOutput combines the lines from the given output into a single string.
 func formatOutput(output []string) string {
-	cleanString := removeEscapeSequences(strings.Join(output, "\n"))
-	return escapeIllegalChars(cleanString)
+	return escapeIllegalChars(strings.Join(output, "\n"))
 }
 
 func escapeIllegalChars(str string) string {
+	str = stripansi.Strip(str)
 	return strings.Map(func(r rune) rune {
 		if isInCharacterRange(r) {
 			return r
 		}
 		return '\uFFFD'
 	}, str)
-}
-
-func removeEscapeSequences(s string) string {
-	// Define a regular expression to match ANSI escape sequences
-	ansiEscapeRegex := regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
-	// Remove ANSI escape sequences from the input string
-	cleanString := ansiEscapeRegex.ReplaceAllString(s, "")
-	return cleanString
 }
 
 // Decide whether the given rune is in the XML Character Range, per

--- a/junit/junit.go
+++ b/junit/junit.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 	"time"
+	"regexp"
 
 	"github.com/jstemmer/go-junit-report/v2/gtr"
 )
@@ -251,7 +252,8 @@ func formatDuration(d time.Duration) string {
 
 // formatOutput combines the lines from the given output into a single string.
 func formatOutput(output []string) string {
-	return escapeIllegalChars(strings.Join(output, "\n"))
+	cleanString := removeEscapeSequences(strings.Join(output, "\n"))
+	return escapeIllegalChars(strings.Join(cleanString, "\n"))
 }
 
 func escapeIllegalChars(str string) string {
@@ -261,6 +263,14 @@ func escapeIllegalChars(str string) string {
 		}
 		return '\uFFFD'
 	}, str)
+}
+
+func removeEscapeSequences(s string) string {
+	// Define a regular expression to match ANSI escape sequences
+	ansiEscapeRegex := regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+	// Remove ANSI escape sequences from the input string
+	cleanString := ansiEscapeRegex.ReplaceAllString(s, "")
+	return cleanString
 }
 
 // Decide whether the given rune is in the XML Character Range, per

--- a/junit/junit.go
+++ b/junit/junit.go
@@ -6,9 +6,9 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"time"
-	"regexp"
 
 	"github.com/jstemmer/go-junit-report/v2/gtr"
 )
@@ -253,7 +253,7 @@ func formatDuration(d time.Duration) string {
 // formatOutput combines the lines from the given output into a single string.
 func formatOutput(output []string) string {
 	cleanString := removeEscapeSequences(strings.Join(output, "\n"))
-	return escapeIllegalChars(strings.Join(cleanString, "\n"))
+	return escapeIllegalChars(cleanString)
 }
 
 func escapeIllegalChars(str string) string {

--- a/junit/junit_test.go
+++ b/junit/junit_test.go
@@ -35,7 +35,7 @@ func TestCreateFromReport(t *testing.T) {
 					{
 						Name:   "TestRemoveOutputANSI",
 						Result: gtr.Pass,
-						Output: []string{"This contains some", "\x1b[1mANSI\x1b[0m", "sequence"},
+						Output: []string{"This contains some", "\x1b[38;5;140mANSI\x1b[0m", "sequence"},
 					},
 					{
 						Name:   "TestFail",

--- a/junit/junit_test.go
+++ b/junit/junit_test.go
@@ -33,6 +33,11 @@ func TestCreateFromReport(t *testing.T) {
 						Output: []string{"\x00\v\f \t\\"},
 					},
 					{
+						Name:   "TestRemoveOutputANSI",
+						Result: gtr.Pass,
+						Output: []string{"This contains some", "\x1b[1mANSI\x1b[0m", "sequence"},
+					},
+					{
 						Name:   "TestFail",
 						Result: gtr.Fail,
 						Output: []string{"fail"},
@@ -53,14 +58,14 @@ func TestCreateFromReport(t *testing.T) {
 	}
 
 	want := Testsuites{
-		Tests:    7,
+		Tests:    8,
 		Errors:   3,
 		Failures: 1,
 		Skipped:  1,
 		Suites: []Testsuite{
 			{
 				Name:      "package/name",
-				Tests:     7,
+				Tests:     8,
 				Errors:    3,
 				ID:        0,
 				Failures:  1,
@@ -83,6 +88,12 @@ func TestCreateFromReport(t *testing.T) {
 						Classname: "package/name",
 						Time:      "0.000",
 						SystemOut: &Output{Data: `��� 	\`},
+					},
+					{
+						Name:      "TestRemoveOutputANSI",
+						Classname: "package/name",
+						Time:      "0.000",
+						SystemOut: &Output{Data: "This contains some\nANSI\nsequence"},
 					},
 					{
 						Name:      "TestFail",
@@ -193,8 +204,8 @@ func TestWriteXML(t *testing.T) {
 
 	var suites Testsuites
 
-	ts := Testsuite{Name:"Example"}
-	ts.AddTestcase(Testcase{Name: "Test", })
+	ts := Testsuite{Name: "Example"}
+	ts.AddTestcase(Testcase{Name: "Test"})
 	suites.AddSuite(ts)
 
 	var buf bytes.Buffer


### PR DESCRIPTION
Refs https://github.com/jstemmer/go-junit-report/pull/162