### PR TITLE
feat: populate skipped message with last line of test output

### DIFF
--- a/junit/junit.go
+++ b/junit/junit.go
@@ -230,9 +230,18 @@ func createTestcaseForTest(pkgName string, test gtr.Test) Testcase {
 			Data:    formatOutput(test.Output),
 		}
 	} else if test.Result == gtr.Skip {
+		message := ""
+		data := ""
+		if len(test.Output) > 0 {
+			lastIdx := len(test.Output) - 1
+			message = strings.TrimSpace(test.Output[lastIdx])
+			if len(test.Output) > 1 {
+				data = formatOutput(test.Output[:lastIdx])
+			}
+		}
 		tc.Skipped = &Result{
-			Message: "Skipped",
-			Data:    formatOutput(test.Output),
+			Message: message,
+			Data:    data,
 		}
 	} else if test.Result == gtr.Unknown {
 		tc.Error = &Result{

--- a/junit/junit_test.go
+++ b/junit/junit_test.go
@@ -105,7 +105,7 @@ func TestCreateFromReport(t *testing.T) {
 						Name:      "TestSkip",
 						Classname: "package/name",
 						Time:      "0.000",
-						Skipped:   &Result{Message: "Skipped"},
+						Skipped:   &Result{},
 					},
 					{
 						Name:      "TestIncomplete",

--- a/testdata/001-report.xml
+++ b/testdata/001-report.xml
@@ -28,10 +28,10 @@
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase name="TestSkip" classname="package/skip" time="0.020">
-			<skipped message="Skipped"><![CDATA[    skip_test.go:6: skip message]]></skipped>
+			<skipped message="skip_test.go:6: skip message"></skipped>
 		</testcase>
 		<testcase name="TestSkipNow" classname="package/skip" time="0.130">
-			<skipped message="Skipped"><![CDATA[    skip_test.go:10: log message]]></skipped>
+			<skipped message="skip_test.go:10: log message"></skipped>
 		</testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/012-report.xml
+++ b/testdata/012-report.xml
@@ -14,7 +14,7 @@
 			<failure message="Failed"><![CDATA[    subtests_test.go:10: error message]]></failure>
 		</testcase>
 		<testcase name="TestSubtests/Subtest#02" classname="package/subtests" time="0.000">
-			<skipped message="Skipped"><![CDATA[    subtests_test.go:13: skip message]]></skipped>
+			<skipped message="subtests_test.go:13: skip message"></skipped>
 		</testcase>
 		<testcase name="TestNestedSubtests" classname="package/subtests" time="0.000"></testcase>
 		<testcase name="TestNestedSubtests/a#1" classname="package/subtests" time="0.000"></testcase>

--- a/testdata/036-report.xml
+++ b/testdata/036-report.xml
@@ -11,7 +11,7 @@
 			<failure message="Failed"><![CDATA[    bench_test.go:10: fatal message]]></failure>
 		</testcase>
 		<testcase name="BenchmarkSkip" classname="package/name/benchfail" time="0.000">
-			<skipped message="Skipped"><![CDATA[    bench_test.go:14: skip message]]></skipped>
+			<skipped message="bench_test.go:14: skip message"></skipped>
 		</testcase>
 		<system-out><![CDATA[goos: linux
 goarch: amd64

--- a/testdata/107-report.xml
+++ b/testdata/107-report.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2" skipped="2">
-	<testsuite name="package/name/skip" tests="2" failures="0" errors="0" id="0" hostname="hostname" skipped="2" time="0.001" timestamp="2022-01-01T00:00:00Z">
+<testsuites tests="4" skipped="4">
+	<testsuite name="package/skip" tests="4" failures="0" errors="0" id="0" hostname="hostname" skipped="4" time="0.000" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase name="TestSkip" classname="package/name/skip" time="0.000">
-			<skipped message="Skipped"><![CDATA[    skip_test.go:6: skip message]]></skipped>
+		<testcase name="TestSkip" classname="package/skip" time="0.000">
+			<skipped message="skip_test.go:6: skip message"></skipped>
 		</testcase>
-		<testcase name="TestSkipNow" classname="package/name/skip" time="0.000">
-			<skipped message="Skipped"><![CDATA[    skip_test.go:10: log message]]></skipped>
+		<testcase name="TestSkipNow" classname="package/skip" time="0.000">
+			<skipped message="skip_test.go:10: log message"></skipped>
+		</testcase>
+		<testcase name="TestSkipNoMessage" classname="package/skip" time="0.000">
+			<skipped message=""></skipped>
+		</testcase>
+		<testcase name="TestSkipLogMessage" classname="package/skip" time="0.000">
+			<skipped message="skip_test.go:20: skip message"><![CDATA[    skip_test.go:19: log message]]></skipped>
 		</testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/107-skip.gojson.txt
+++ b/testdata/107-skip.gojson.txt
@@ -1,13 +1,23 @@
-{"Time":"2019-10-09T00:00:00.329193863+00:00","Action":"run","Package":"package/name/skip","Test":"TestSkip"}
-{"Time":"2019-10-09T00:00:00.329288607+00:00","Action":"output","Package":"package/name/skip","Test":"TestSkip","Output":"=== RUN   TestSkip\n"}
-{"Time":"2019-10-09T00:00:00.32929713+00:00","Action":"output","Package":"package/name/skip","Test":"TestSkip","Output":"    skip_test.go:6: skip message\n"}
-{"Time":"2019-10-09T00:00:00.329302577+00:00","Action":"output","Package":"package/name/skip","Test":"TestSkip","Output":"--- SKIP: TestSkip (0.00s)\n"}
-{"Time":"2019-10-09T00:00:00.329305698+00:00","Action":"skip","Package":"package/name/skip","Test":"TestSkip","Elapsed":0}
-{"Time":"2019-10-09T00:00:00.329309504+00:00","Action":"run","Package":"package/name/skip","Test":"TestSkipNow"}
-{"Time":"2019-10-09T00:00:00.329312988+00:00","Action":"output","Package":"package/name/skip","Test":"TestSkipNow","Output":"=== RUN   TestSkipNow\n"}
-{"Time":"2019-10-09T00:00:00.329315853+00:00","Action":"output","Package":"package/name/skip","Test":"TestSkipNow","Output":"    skip_test.go:10: log message\n"}
-{"Time":"2019-10-09T00:00:00.329319388+00:00","Action":"output","Package":"package/name/skip","Test":"TestSkipNow","Output":"--- SKIP: TestSkipNow (0.00s)\n"}
-{"Time":"2019-10-09T00:00:00.329322008+00:00","Action":"skip","Package":"package/name/skip","Test":"TestSkipNow","Elapsed":0}
-{"Time":"2019-10-09T00:00:00.329324691+00:00","Action":"output","Package":"package/name/skip","Output":"PASS\n"}
-{"Time":"2019-10-09T00:00:00.329392899+00:00","Action":"output","Package":"package/name/skip","Output":"ok  \tpackage/name/skip\t0.001s\n"}
-{"Time":"2019-10-09T00:00:00.329615729+00:00","Action":"pass","Package":"package/name/skip","Elapsed":0.001}
+{"Time":"2023-02-19T23:15:21.674171Z","Action":"run","Package":"package/skip","Test":"TestSkip"}
+{"Time":"2023-02-19T23:15:21.674342Z","Action":"output","Package":"package/skip","Test":"TestSkip","Output":"=== RUN   TestSkip\n"}
+{"Time":"2023-02-19T23:15:21.674352Z","Action":"output","Package":"package/skip","Test":"TestSkip","Output":"    skip_test.go:6: skip message\n"}
+{"Time":"2023-02-19T23:15:21.674371Z","Action":"output","Package":"package/skip","Test":"TestSkip","Output":"--- SKIP: TestSkip (0.00s)\n"}
+{"Time":"2023-02-19T23:15:21.674374Z","Action":"skip","Package":"package/skip","Test":"TestSkip","Elapsed":0}
+{"Time":"2023-02-19T23:15:21.674382Z","Action":"run","Package":"package/skip","Test":"TestSkipNow"}
+{"Time":"2023-02-19T23:15:21.674386Z","Action":"output","Package":"package/skip","Test":"TestSkipNow","Output":"=== RUN   TestSkipNow\n"}
+{"Time":"2023-02-19T23:15:21.674388Z","Action":"output","Package":"package/skip","Test":"TestSkipNow","Output":"    skip_test.go:10: log message\n"}
+{"Time":"2023-02-19T23:15:21.674391Z","Action":"output","Package":"package/skip","Test":"TestSkipNow","Output":"--- SKIP: TestSkipNow (0.00s)\n"}
+{"Time":"2023-02-19T23:15:21.674394Z","Action":"skip","Package":"package/skip","Test":"TestSkipNow","Elapsed":0}
+{"Time":"2023-02-19T23:15:21.6744Z","Action":"run","Package":"package/skip","Test":"TestSkipNoMessage"}
+{"Time":"2023-02-19T23:15:21.674402Z","Action":"output","Package":"package/skip","Test":"TestSkipNoMessage","Output":"=== RUN   TestSkipNoMessage\n"}
+{"Time":"2023-02-19T23:15:21.674405Z","Action":"output","Package":"package/skip","Test":"TestSkipNoMessage","Output":"--- SKIP: TestSkipNoMessage (0.00s)\n"}
+{"Time":"2023-02-19T23:15:21.674407Z","Action":"skip","Package":"package/skip","Test":"TestSkipNoMessage","Elapsed":0}
+{"Time":"2023-02-19T23:15:21.674409Z","Action":"run","Package":"package/skip","Test":"TestSkipLogMessage"}
+{"Time":"2023-02-19T23:15:21.674411Z","Action":"output","Package":"package/skip","Test":"TestSkipLogMessage","Output":"=== RUN   TestSkipLogMessage\n"}
+{"Time":"2023-02-19T23:15:21.67442Z","Action":"output","Package":"package/skip","Test":"TestSkipLogMessage","Output":"    skip_test.go:19: log message\n"}
+{"Time":"2023-02-19T23:15:21.674426Z","Action":"output","Package":"package/skip","Test":"TestSkipLogMessage","Output":"    skip_test.go:20: skip message\n"}
+{"Time":"2023-02-19T23:15:21.674432Z","Action":"output","Package":"package/skip","Test":"TestSkipLogMessage","Output":"--- SKIP: TestSkipLogMessage (0.00s)\n"}
+{"Time":"2023-02-19T23:15:21.674434Z","Action":"skip","Package":"package/skip","Test":"TestSkipLogMessage","Elapsed":0}
+{"Time":"2023-02-19T23:15:21.674439Z","Action":"output","Package":"package/skip","Output":"PASS\n"}
+{"Time":"2023-02-19T23:15:21.674441Z","Action":"output","Package":"package/skip","Output":"ok  \tpackage/skip\n"}
+{"Time":"2023-02-19T23:15:21.674448Z","Action":"pass","Package":"package/skip","Elapsed":0}

--- a/testdata/110-report.xml
+++ b/testdata/110-report.xml
@@ -11,7 +11,7 @@
 			<failure message="Failed"><![CDATA[    bench_test.go:10: fatal message]]></failure>
 		</testcase>
 		<testcase name="BenchmarkSkip" classname="package/name/benchfail" time="0.000">
-			<skipped message="Skipped"><![CDATA[    bench_test.go:14: skip message]]></skipped>
+			<skipped message="bench_test.go:14: skip message"></skipped>
 		</testcase>
 		<system-out><![CDATA[goos: linux
 goarch: amd64

--- a/testdata/src/skip/skip_test.go
+++ b/testdata/src/skip/skip_test.go
@@ -10,3 +10,12 @@ func TestSkipNow(t *testing.T) {
 	t.Log("log message")
 	t.SkipNow()
 }
+
+func TestSkipNoMessage(t *testing.T) {
+	t.SkipNow()
+}
+
+func TestSkipLogMessage(t *testing.T) {
+	t.Log("log message")
+	t.Skip("skip message")
+}


### PR DESCRIPTION
Refs https://github.com/jstemmer/go-junit-report/pull/158